### PR TITLE
BUGFIX/MINOR(xcute): Add missing tag configure on reload of gridinit

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,7 @@
 
 - name: "reload gridinit to apply the new configuration"
   shell: gridinit_cmd reload
+  tags: configure
   when:
     - _xcute_conf is changed
     - not openio_xcute_provision_only


### PR DESCRIPTION
 ##### SUMMARY

The tag `configure` was missing on the gridinit_cmd reload

 ##### IMPACT
 N/A

 ##### ADDITIONAL INFORMATION